### PR TITLE
feat: Implement frontend for Teams feature

### DIFF
--- a/Backend/src/controllers/auth.controller.js
+++ b/Backend/src/controllers/auth.controller.js
@@ -37,6 +37,7 @@ export const signup = async (req, res) => {
         fullName: newUser.fullName,
         email: newUser.email,
         profilePic: newUser.profilePic,
+        team: newUser.team, // Explicitly include team (will be null)
       });
     } else {
       res.status(400).json({ message: "Invalid user data" });
@@ -50,7 +51,7 @@ export const signup = async (req, res) => {
 export const login = async (req, res) => {
   const { email, password } = req.body;
   try {
-    const user = await User.findOne({ email });
+    const user = await User.findOne({ email }).populate("team"); // New: populate team
 
     if (!user) {
       return res.status(400).json({ message: "Invalid credentials" });
@@ -68,6 +69,7 @@ export const login = async (req, res) => {
       fullName: user.fullName,
       email: user.email,
       profilePic: user.profilePic,
+      team: user.team, // This will be the populated team object or null
     });
   } catch (error) {
     console.log("Error in login controller", error.message);

--- a/Backend/src/lib/socket.js
+++ b/Backend/src/lib/socket.js
@@ -1,37 +1,77 @@
 import { Server } from "socket.io";
 import http from "http";
 import express from "express";
+import User from "../models/user.model.js"; // Needed to fetch user's team on initial connection
 
 const app = express();
 const server = http.createServer(app);
 
 const io = new Server(server, {
   cors: {
-    origin: ["http://localhost:5173"],
+    origin: ["http://localhost:3000", "http://127.0.0.1:3000"], // Frontend URL
+    methods: ["GET", "POST"],
   },
 });
 
-export function getReceiverSocketId(userId) {
-  return userSocketMap[userId];
-}
+const userSocketMap = {}; // { userId: socketId }
 
-// used to store online users
-const userSocketMap = {}; // {userId: socketId}
+export const getReceiverSocketId = (receiverId) => {
+  return userSocketMap[receiverId];
+};
 
-io.on("connection", (socket) => {
-  console.log("A user connected", socket.id);
-
+io.on("connection", async (socket) => {
+  console.log("A user connected:", socket.id);
   const userId = socket.handshake.query.userId;
-  if (userId) userSocketMap[userId] = socket.id;
 
-  // io.emit() is used to send events to all the connected clients
-  io.emit("getOnlineUsers", Object.keys(userSocketMap));
+  if (userId && userId !== "undefined") {
+    userSocketMap[userId] = socket.id;
+    io.emit("getOnlineUsers", Object.keys(userSocketMap));
+    console.log(`User ${userId} connected, socket ID: ${socket.id}. Online users:`, Object.keys(userSocketMap));
+
+    // --- Automatic room joining on connection based on user's current team ---
+    try {
+      const user = await User.findById(userId).select("team"); // Fetch user with their team ID
+      if (user && user.team) {
+        const teamId = user.team.toString();
+        socket.join(teamId);
+        socket.currentTeamRoom = teamId; // Store current team room on socket object
+        console.log(`Socket ${socket.id} for user ${userId} automatically joined room ${teamId}`);
+      }
+    } catch (error) {
+      console.error(`Error fetching user ${userId} for auto room joining:`, error.message);
+    }
+    // --- End automatic room joining ---
+  }
+
+  socket.on("joinTeamRoom", (teamId) => {
+    if (socket.currentTeamRoom && socket.currentTeamRoom !== teamId) {
+      socket.leave(socket.currentTeamRoom); // Leave previous room if any
+      console.log(`Socket ${socket.id} left room ${socket.currentTeamRoom}`);
+    }
+    socket.join(teamId);
+    socket.currentTeamRoom = teamId; // Store current team for this socket
+    console.log(`Socket ${socket.id} joined room ${teamId}`);
+  });
+
+  socket.on("leaveTeamRoom", (teamId) => {
+    socket.leave(teamId);
+    if (socket.currentTeamRoom === teamId) {
+      socket.currentTeamRoom = null; // Clear stored team room
+    }
+    console.log(`Socket ${socket.id} left room ${teamId}`);
+  });
 
   socket.on("disconnect", () => {
-    console.log("A user disconnected", socket.id);
-    delete userSocketMap[userId];
-    io.emit("getOnlineUsers", Object.keys(userSocketMap));
+    console.log("User disconnected:", socket.id);
+    if (userId && userId !== "undefined") {
+      delete userSocketMap[userId];
+      io.emit("getOnlineUsers", Object.keys(userSocketMap));
+      console.log(`User ${userId} disconnected. Online users:`, Object.keys(userSocketMap));
+    }
+    // No need to explicitly leave 'socket.currentTeamRoom' here if relying on Socket.IO's auto-cleanup on disconnect.
+    // However, if managing room state more explicitly, you might do it here.
+    // Socket.IO automatically removes the socket from all rooms it was part of upon disconnection.
   });
 });
 
-export { io, app, server };
+export { io, server, app };

--- a/Backend/src/middleware/auth.middleware.js
+++ b/Backend/src/middleware/auth.middleware.js
@@ -1,5 +1,7 @@
+// Backend/src/middleware/auth.middleware.js
 import jwt from "jsonwebtoken";
 import User from "../models/user.model.js";
+// Team model might not be directly used here but ensuring User model has ref correct.
 
 export const protectRoute = async (req, res, next) => {
   try {
@@ -15,13 +17,14 @@ export const protectRoute = async (req, res, next) => {
       return res.status(401).json({ message: "Unauthorized - Invalid Token" });
     }
 
-    const user = await User.findById(decoded.userId).select("-password");
+    // Populate the 'team' field when fetching the user
+    const user = await User.findById(decoded.userId).select("-password").populate("team");
 
     if (!user) {
       return res.status(404).json({ message: "User not found" });
     }
 
-    req.user = user;
+    req.user = user; // req.user will now have the populated team object if a team exists
 
     next();
   } catch (error) {

--- a/Frontend/src/App.jsx
+++ b/Frontend/src/App.jsx
@@ -5,6 +5,7 @@ import SignUpPage from "./pages/SignUpPage";
 import LoginPage from "./pages/LoginPage";
 import SettingsPage from "./pages/SettingsPage";
 import ProfilePage from "./pages/ProfilePage";
+import TeamsPage from "./pages/TeamsPage"; // Import the new page
 
 import { Routes, Route, Navigate } from "react-router-dom";
 import { useAuthStore } from "./store/useAuthStore";
@@ -15,18 +16,18 @@ import { Loader } from "lucide-react";
 import { Toaster } from "react-hot-toast";
 
 const App = () => {
-  const { authUser, checkAuth, isCheckingAuth, onlineUsers } = useAuthStore();
+  const { authUser, checkAuth, isCheckingAuth } = useAuthStore(); // Removed onlineUsers from here
   const { theme } = useThemeStore();
 
-  console.log({ onlineUsers });
+  // console.log({ onlineUsers }); // Removed
 
   useEffect(() => {
     checkAuth();
   }, [checkAuth]);
 
-  console.log({ authUser });
+  // console.log({ authUser }); // Keep for debugging if needed
 
-  if (isCheckingAuth && !authUser)
+  if (isCheckingAuth && !authUser) // Keep this check
     return (
       <div className="flex items-center justify-center h-screen">
         <Loader className="size-10 animate-spin" />
@@ -41,8 +42,9 @@ const App = () => {
         <Route path="/" element={authUser ? <HomePage /> : <Navigate to="/login" />} />
         <Route path="/signup" element={!authUser ? <SignUpPage /> : <Navigate to="/" />} />
         <Route path="/login" element={!authUser ? <LoginPage /> : <Navigate to="/" />} />
-        <Route path="/settings" element={<SettingsPage />} />
+        <Route path="/settings" element={<SettingsPage />} /> {/* Assuming settings can be accessed by all or handles auth internally */}
         <Route path="/profile" element={authUser ? <ProfilePage /> : <Navigate to="/login" />} />
+        <Route path="/teams" element={authUser ? <TeamsPage /> : <Navigate to="/login" />} /> {/* Add new route */}
       </Routes>
 
       <Toaster />

--- a/Frontend/src/components/ChatContainer.jsx
+++ b/Frontend/src/components/ChatContainer.jsx
@@ -1,8 +1,10 @@
+// Frontend/src/components/ChatContainer.jsx
 import { useChatStore } from "../store/useChatStore";
-import { useEffect, useRef } from "react";
+import { useEffect, useRef }
+from "react";
 
 import ChatHeader from "./ChatHeader";
-import MessageInput from "./MessageInput";
+import MessageInput from "./MessageInput"; // Will be adapted in next step
 import MessageSkeleton from "./skeletons/MessageSkeleton";
 import { useAuthStore } from "../store/useAuthStore";
 import { formatMessageTime } from "../lib/utils";
@@ -13,52 +15,78 @@ const ChatContainer = () => {
     getMessages,
     isMessagesLoading,
     selectedUser,
-    subscribeToMessages,
-    unsubscribeFromMessages,
+    addMessageToStore, // Use generic addMessageToStore
   } = useChatStore();
-  const { authUser } = useAuthStore();
+  const { authUser, socket, currentTeam } = useAuthStore(); // Get socket and currentTeam
   const messageEndRef = useRef(null);
 
   useEffect(() => {
-    getMessages(selectedUser._id);
-
-    subscribeToMessages();
-
-    return () => unsubscribeFromMessages();
-  }, [selectedUser._id, getMessages, subscribeToMessages, unsubscribeFromMessages]);
+    if (selectedUser?._id) {
+      getMessages(selectedUser._id);
+    }
+    // Cleanup messages if selectedUser is null (handled by setSelectedUser in store)
+  }, [selectedUser?._id, getMessages]);
 
   useEffect(() => {
-    if (messageEndRef.current && messages) {
+    if (messageEndRef.current && messages.length > 0) {
       messageEndRef.current.scrollIntoView({ behavior: "smooth" });
     }
   }, [messages]);
 
-  if (isMessagesLoading) {
+  useEffect(() => {
+    if (!socket || !selectedUser || !currentTeam) return;
+
+    const handleNewDirectMessage = (newMessage) => {
+      if (
+        newMessage.type === 'direct' &&
+        newMessage.teamId === currentTeam._id &&
+        ((newMessage.senderId?._id === selectedUser._id && newMessage.receiverId?._id === authUser._id) ||
+         (newMessage.senderId?._id === authUser._id && newMessage.receiverId?._id === selectedUser._id))
+      ) {
+        addMessageToStore(newMessage);
+      }
+    };
+
+    socket.on("newMessage", handleNewDirectMessage);
+    return () => {
+      socket.off("newMessage", handleNewDirectMessage);
+    };
+  }, [socket, selectedUser, authUser, currentTeam, addMessageToStore]);
+
+
+  if (isMessagesLoading && selectedUser) { // Only show skeleton if a user is selected and loading
     return (
       <div className="flex-1 flex flex-col overflow-auto">
-        <ChatHeader />
+        <ChatHeader /> {/* ChatHeader might need selectedUser */}
         <MessageSkeleton />
-        <MessageInput />
+        {/* MessageInput will be part of non-loading state */}
       </div>
     );
   }
 
+  if (!selectedUser) {
+      // This case should be handled by HomePage which shows NoChatSelected.
+      // If ChatContainer is rendered without a selectedUser, it's an issue.
+      // For robustness, can add a placeholder, but HomePage logic should prevent this.
+      return <div className="flex-1 flex items-center justify-center"><p>Select a user to chat.</p></div>;
+  }
+
   return (
     <div className="flex-1 flex flex-col overflow-auto">
-      <ChatHeader />
+      <ChatHeader /> {/* ChatHeader uses selectedUser from store */}
 
       <div className="flex-1 overflow-y-auto p-4 space-y-4">
         {messages.map((message) => (
           <div
             key={message._id}
-            className={`chat ${message.senderId === authUser._id ? "chat-end" : "chat-start"}`}
+            className={`chat ${message.senderId._id === authUser._id ? "chat-end" : "chat-start"}`} // Assuming senderId is populated
             ref={messageEndRef}
           >
-            <div className=" chat-image avatar">
-              <div className="size-10 rounded-full border">
+            <div className="chat-image avatar">
+              <div className="w-10 rounded-full border">
                 <img
                   src={
-                    message.senderId === authUser._id
+                    message.senderId._id === authUser._id
                       ? authUser.profilePic || "/avatar.png"
                       : selectedUser.profilePic || "/avatar.png"
                   }
@@ -66,26 +94,34 @@ const ChatContainer = () => {
                 />
               </div>
             </div>
-            <div className="chat-header mb-1">
-              <time className="text-xs opacity-50 ml-1">
+            <div className="chat-header mb-1 flex items-center gap-2">
+               {/* For direct messages, sender name is not needed if it's just "You" or selectedUser.name */}
+               {/* <span className="text-sm font-medium">{message.senderId._id === authUser._id ? "You" : selectedUser.fullName}</span> */}
+              <time className="text-xs opacity-50">
                 {formatMessageTime(message.createdAt)}
               </time>
             </div>
-            <div className="chat-bubble flex flex-col">
+            <div className={`chat-bubble flex flex-col ${message.senderId._id === authUser._id ? "bg-primary text-primary-content" : ""}`}>
               {message.image && (
                 <img
                   src={message.image}
                   alt="Attachment"
-                  className="sm:max-w-[200px] rounded-md mb-2"
+                  className="sm:max-w-[200px] rounded-md mb-2 object-cover"
                 />
               )}
               {message.text && <p>{message.text}</p>}
             </div>
           </div>
         ))}
+         {messages.length === 0 && !isMessagesLoading && (
+            <div className="text-center text-zinc-500 mt-10">
+                No messages yet with {selectedUser.fullName}. Say hi!
+            </div>
+        )}
       </div>
 
-      <MessageInput />
+      {/* MessageInput will be passed chatId={selectedUser._id} and messageType="direct" */}
+      <MessageInput chatId={selectedUser._id} messageType="direct" />
     </div>
   );
 };

--- a/Frontend/src/components/MessageInput.jsx
+++ b/Frontend/src/components/MessageInput.jsx
@@ -1,16 +1,22 @@
+// Frontend/src/components/MessageInput.jsx
 import { useRef, useState } from "react";
 import { useChatStore } from "../store/useChatStore";
 import { Image, Send, X } from "lucide-react";
 import toast from "react-hot-toast";
 
-const MessageInput = () => {
+// Accept chatId and messageType as props
+const MessageInput = ({ chatId, messageType }) => {
   const [text, setText] = useState("");
   const [imagePreview, setImagePreview] = useState(null);
   const fileInputRef = useRef(null);
+  // The existing sendMessage in useChatStore will be replaced or overloaded
+  // For now, let's assume it's updated to handle this.
   const { sendMessage } = useChatStore();
+  const [isSending, setIsSending] = useState(false);
 
   const handleImageChange = (e) => {
     const file = e.target.files[0];
+    if (!file) return;
     if (!file.type.startsWith("image/")) {
       toast.error("Please select an image file");
       return;
@@ -31,36 +37,46 @@ const MessageInput = () => {
   const handleSendMessage = async (e) => {
     e.preventDefault();
     if (!text.trim() && !imagePreview) return;
+    if (!chatId || !messageType) {
+      toast.error("Chat context is not properly set.");
+      return;
+    }
 
+    setIsSending(true);
     try {
-      await sendMessage({
+      // Call the generic sendMessage with all necessary data
+      await sendMessage({ // This now refers to the new generic sendMessage
+        chatId,
+        messageType,
         text: text.trim(),
         image: imagePreview,
       });
 
-      // Clear form
       setText("");
       setImagePreview(null);
       if (fileInputRef.current) fileInputRef.current.value = "";
     } catch (error) {
-      console.error("Failed to send message:", error);
+      // Error is already toasted by useChatStore's sendMessage
+      console.error("Failed to send message from component:", error);
+    } finally {
+      setIsSending(false);
     }
   };
 
   return (
-    <div className="p-4 w-full">
+    <div className="p-4 w-full border-t border-base-300"> {/* Added border */}
       {imagePreview && (
         <div className="mb-3 flex items-center gap-2">
           <div className="relative">
             <img
               src={imagePreview}
               alt="Preview"
-              className="w-20 h-20 object-cover rounded-lg border border-zinc-700"
+              className="w-20 h-20 object-cover rounded-lg border border-base-300" // Use base-300 for border
             />
             <button
               onClick={removeImage}
-              className="absolute -top-1.5 -right-1.5 w-5 h-5 rounded-full bg-base-300
-              flex items-center justify-center"
+              className="absolute -top-1.5 -right-1.5 w-5 h-5 rounded-full bg-error text-error-content
+              flex items-center justify-center" // Changed to error theme for delete
               type="button"
             >
               <X className="size-3" />
@@ -77,6 +93,7 @@ const MessageInput = () => {
             placeholder="Type a message..."
             value={text}
             onChange={(e) => setText(e.target.value)}
+            disabled={isSending}
           />
           <input
             type="file"
@@ -84,23 +101,25 @@ const MessageInput = () => {
             className="hidden"
             ref={fileInputRef}
             onChange={handleImageChange}
+            disabled={isSending}
           />
 
           <button
             type="button"
-            className={`hidden sm:flex btn btn-circle
-                     ${imagePreview ? "text-emerald-500" : "text-zinc-400"}`}
+            className={`hidden sm:flex btn btn-circle btn-sm sm:btn-md
+                            ${imagePreview ? "text-primary" : "text-zinc-400"}`} // Use primary color if image
             onClick={() => fileInputRef.current?.click()}
+            disabled={isSending}
           >
             <Image size={20} />
           </button>
         </div>
         <button
           type="submit"
-          className="btn btn-sm btn-circle"
-          disabled={!text.trim() && !imagePreview}
+          className="btn btn-sm sm:btn-md btn-circle btn-primary" // Use primary color
+          disabled={!text.trim() && !imagePreview || isSending}
         >
-          <Send size={22} />
+          {isSending ? <span className="loading loading-spinner loading-xs"></span> : <Send size={22} />}
         </button>
       </form>
     </div>

--- a/Frontend/src/components/Navbar.jsx
+++ b/Frontend/src/components/Navbar.jsx
@@ -1,6 +1,6 @@
 import { Link } from "react-router-dom";
 import { useAuthStore } from "../store/useAuthStore";
-import { AudioWaveform, LogOut,  Settings, User } from "lucide-react";
+import { AudioWaveform, LogOut,  Settings, User, Users } from "lucide-react"; // Added Users
 
 const Navbar = () => {
   const { logout, authUser } = useAuthStore();
@@ -22,6 +22,15 @@ const Navbar = () => {
           </div>
 
           <div className="flex items-center gap-2">
+            {authUser && ( // Teams link only if authenticated
+              <Link
+                to="/teams"
+                className="btn btn-sm gap-2 transition-colors"
+              >
+                <Users className="w-4 h-4" />
+                <span className="hidden sm:inline">Teams</span>
+              </Link>
+            )}
             <Link
               to={"/settings"}
               className={`

--- a/Frontend/src/components/NoChatSelected.jsx
+++ b/Frontend/src/components/NoChatSelected.jsx
@@ -1,27 +1,15 @@
-import { AudioWaveform } from "lucide-react";
+// Frontend/src/components/NoChatSelected.jsx
+import { MessagesSquare } from "lucide-react";
 
-const NoChatSelected = () => {
+const NoChatSelected = ({ message }) => {
   return (
-    <div className="w-full flex flex-1 flex-col items-center justify-center p-16 bg-base-100/50">
-      <div className="max-w-md text-center space-y-6">
-        {/* Icon Display */}
-        <div className="flex justify-center gap-4 mb-4">
-          <div className="relative">
-            <div
-              className="w-16 h-16 rounded-2xl bg-primary/10 flex items-center
-             justify-center animate-bounce"
-            >
-              <AudioWaveform className="w-8 h-8 text-primary " />
-            </div>
-          </div>
-        </div>
-
-        {/* Welcome Text */}
-        <h2 className="text-2xl font-bold">Welcome to Wave!</h2>
-        <p className="text-base-content/60">
-          Select a conversation from the sidebar to start chatting
-        </p>
-      </div>
+    <div className="flex-1 flex flex-col items-center justify-center p-10 text-center">
+      <MessagesSquare size={80} className="text-zinc-400 mb-6" />
+      <h2 className="text-2xl font-semibold text-zinc-300 mb-2">Welcome!</h2>
+      <p className="text-zinc-400">
+        {message || "Select a conversation from the sidebar to start messaging."}
+      </p>
+      {/* Optionally, if no team, guide to team creation/join page */}
     </div>
   );
 };

--- a/Frontend/src/components/Sidebar.jsx
+++ b/Frontend/src/components/Sidebar.jsx
@@ -1,22 +1,48 @@
+// Frontend/src/components/Sidebar.jsx
 import { useEffect, useState } from "react";
 import { useChatStore } from "../store/useChatStore";
 import { useAuthStore } from "../store/useAuthStore";
 import SidebarSkeleton from "./skeletons/SidebarSkeleton";
-import { Users } from "lucide-react";
+import { Users, LogIn } from "lucide-react"; // Added LogIn for link icon
+import { Link } from "react-router-dom"; // For linking to /teams
 
 const Sidebar = () => {
   const { getUsers, users, selectedUser, setSelectedUser, isUsersLoading } = useChatStore();
-
-  const { onlineUsers } = useAuthStore();
+  const { onlineUsers, currentTeam, authUser } = useAuthStore(); // Added currentTeam
   const [showOnlineOnly, setShowOnlineOnly] = useState(false);
 
   useEffect(() => {
-    getUsers();
-  }, [getUsers]);
+    // Only fetch users if the user is part of a team
+    if (currentTeam) {
+      getUsers();
+    }
+  }, [getUsers, currentTeam]);
 
+  // Filter users based on online status and ensure they are part of the current team.
+  // The `getUsers` endpoint should already only return team members.
   const filteredUsers = showOnlineOnly
     ? users.filter((user) => onlineUsers.includes(user._id))
     : users;
+
+  // Calculate online team members count for display
+  // This assumes `users` are already filtered by team by the `getUsers` call
+  const onlineTeamMembersCount = users.filter(user => onlineUsers.includes(user._id) && user._id !== authUser?._id).length;
+
+
+  if (!currentTeam) {
+    return (
+      <aside className="h-full w-20 lg:w-72 border-r border-base-300 flex flex-col transition-all duration-200 p-5 justify-center items-center">
+        <div className="text-center">
+          <Users size={48} className="text-zinc-500 mb-4 mx-auto" />
+          <p className="mb-4 text-zinc-400 hidden lg:block">You are not in a team.</p>
+          <Link to="/teams" className="btn btn-primary btn-sm lg:btn-md">
+            <LogIn size={18} className="mr-1 hidden lg:inline" />
+            Join or Create Team
+          </Link>
+        </div>
+      </aside>
+    );
+  }
 
   if (isUsersLoading) return <SidebarSkeleton />;
 
@@ -25,9 +51,8 @@ const Sidebar = () => {
       <div className="border-b border-base-300 w-full p-5">
         <div className="flex items-center gap-2">
           <Users className="size-6" />
-          <span className="font-medium hidden lg:block">Contacts</span>
+          <span className="font-medium hidden lg:block">Team Contacts</span>
         </div>
-        {/* TODO: Online filter toggle */}
         <div className="mt-3 hidden lg:flex items-center gap-2">
           <label className="cursor-pointer flex items-center gap-2">
             <input
@@ -38,7 +63,8 @@ const Sidebar = () => {
             />
             <span className="text-sm">Show online only</span>
           </label>
-          <span className="text-xs text-zinc-500">({onlineUsers.length - 1} online)</span>
+          {/* Display count of online team members */}
+          <span className="text-xs text-zinc-500">({onlineTeamMembersCount} online)</span>
         </div>
       </div>
 
@@ -56,18 +82,17 @@ const Sidebar = () => {
             <div className="relative mx-auto lg:mx-0">
               <img
                 src={user.profilePic || "/avatar.png"}
-                alt={user.name}
+                alt={user.fullName} // Changed from user.name to user.fullName
                 className="size-12 object-cover rounded-full"
               />
               {onlineUsers.includes(user._id) && (
                 <span
                   className="absolute bottom-0 right-0 size-3 bg-green-500 
-                  rounded-full ring-2 ring-zinc-900"
+                  rounded-full ring-2 ring-base-100" // Ring color changed for better visibility
                 />
               )}
             </div>
 
-            {/* User info - only visible on larger screens */}
             <div className="hidden lg:block text-left min-w-0">
               <div className="font-medium truncate">{user.fullName}</div>
               <div className="text-sm text-zinc-400">
@@ -77,8 +102,11 @@ const Sidebar = () => {
           </button>
         ))}
 
-        {filteredUsers.length === 0 && (
-          <div className="text-center text-zinc-500 py-4">No online users</div>
+        {filteredUsers.length === 0 && !isUsersLoading && (
+          <div className="text-center text-zinc-500 py-4 hidden lg:block">No other members in this team.</div>
+        )}
+         {filteredUsers.length === 0 && !isUsersLoading && users.length > 0 && ( // handles only self in team
+          <div className="text-center text-zinc-500 py-4 hidden lg:block">You are the only one here.</div>
         )}
       </div>
     </aside>

--- a/Frontend/src/components/TeamChatContainer.jsx
+++ b/Frontend/src/components/TeamChatContainer.jsx
@@ -1,0 +1,144 @@
+// Frontend/src/components/TeamChatContainer.jsx
+import { useEffect, useRef } from "react";
+import { useChatStore } from "../store/useChatStore";
+import { useAuthStore } from "../store/useAuthStore";
+import MessageInput from "./MessageInput"; // Will be adapted later
+import MessageSkeleton from "./skeletons/MessageSkeleton";
+import { formatMessageTime } from "../lib/utils";
+import { Users } from "lucide-react"; // Icon for header
+
+const TeamChatContainer = () => {
+  const {
+    teamMessages,
+    getTeamMessages,
+    isTeamMessagesLoading,
+    addMessageToStore, // Will be used by socket listener
+  } = useChatStore();
+  const { authUser, currentTeam, socket } = useAuthStore();
+  const messageEndRef = useRef(null);
+
+  useEffect(() => {
+    if (currentTeam?._id) {
+      getTeamMessages(currentTeam._id);
+    }
+  }, [currentTeam?._id, getTeamMessages]);
+
+  useEffect(() => {
+    if (messageEndRef.current && teamMessages.length > 0) {
+      messageEndRef.current.scrollIntoView({ behavior: "smooth" });
+    }
+  }, [teamMessages]);
+
+  useEffect(() => {
+    if (!socket || !currentTeam?._id) return;
+
+    const handleNewTeamMessage = (newMessage) => {
+      // Check if the message belongs to the current team and is a team message
+      if (newMessage.teamId === currentTeam._id && newMessage.type === 'team') {
+        // We need a way to get sender's full info if not already in newMessage
+        // For now, the message model on backend sends senderId.
+        // The message object in store should ideally have populated sender info.
+        // Let's assume addMessageToStore handles this or we adapt.
+        addMessageToStore(newMessage);
+      }
+    };
+
+    socket.on("newMessage", handleNewTeamMessage);
+    return () => {
+      socket.off("newMessage", handleNewTeamMessage);
+    };
+  }, [socket, currentTeam?._id, addMessageToStore]);
+
+
+  if (!currentTeam) {
+    return (
+      <div className="flex-1 flex flex-col items-center justify-center p-10">
+        <Users size={60} className="text-zinc-400 mb-4" />
+        <p className="text-xl text-zinc-400">No team selected.</p>
+        <p className="text-zinc-500">Join or create a team to start chatting.</p>
+      </div>
+    );
+  }
+
+  if (isTeamMessagesLoading) {
+    return (
+      <div className="flex-1 flex flex-col overflow-auto">
+        <div className="p-4 border-b border-base-300 flex items-center gap-3">
+          <Users /> <h2 className="font-semibold text-lg">{currentTeam.name} - Team Chat</h2>
+        </div>
+        <MessageSkeleton />
+        {/* MessageInput will be part of the non-loading state */}
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex-1 flex flex-col overflow-auto">
+      {/* Team Chat Header */}
+      <div className="p-4 border-b border-base-300 flex items-center gap-3 sticky top-0 bg-base-100 z-10">
+        <div className="avatar placeholder">
+          <div className="bg-neutral text-neutral-content rounded-full w-10 h-10">
+            <Users size={20}/>
+          </div>
+        </div>
+        <div>
+          <h2 className="font-semibold text-lg">{currentTeam.name}</h2>
+          <span className="text-xs text-zinc-400">Team Group Chat</span>
+        </div>
+      </div>
+
+      {/* Messages Area */}
+      <div className="flex-1 overflow-y-auto p-4 space-y-4">
+        {teamMessages.map((message) => {
+          // To display sender's name, we need it. Assume message.senderId is an object with fullName, profilePic
+          // If not, this part needs adjustment after backend message population or frontend user caching
+          const sender = message.senderId; // This should be the populated sender object
+          const isOwnMessage = sender?._id === authUser?._id;
+
+          return (
+            <div
+              key={message._id}
+              className={`chat ${isOwnMessage ? "chat-end" : "chat-start"}`}
+              ref={messageEndRef}
+            >
+              <div className="chat-image avatar">
+                <div className="w-10 rounded-full border">
+                  <img
+                    src={sender?.profilePic || "/avatar.png"}
+                    alt={sender?.fullName || "User"}
+                  />
+                </div>
+              </div>
+              <div className="chat-header mb-1 flex items-center gap-2">
+                <span className="text-sm font-medium">{isOwnMessage ? "You" : sender?.fullName || "Team Member"}</span>
+                <time className="text-xs opacity-50">
+                  {formatMessageTime(message.createdAt)}
+                </time>
+              </div>
+              <div className={`chat-bubble flex flex-col ${isOwnMessage ? "bg-primary text-primary-content" : ""}`}>
+                {message.image && (
+                  <img
+                    src={message.image}
+                    alt="Attachment"
+                    className="sm:max-w-[200px] rounded-md mb-2 object-cover"
+                  />
+                )}
+                {message.text && <p>{message.text}</p>}
+              </div>
+            </div>
+          );
+        })}
+        {teamMessages.length === 0 && (
+          <div className="text-center text-zinc-500 mt-10">
+            No messages in this team yet. Start the conversation!
+          </div>
+        )}
+      </div>
+
+      {/* Message Input - Will pass type='team' and teamId */}
+      <MessageInput chatId={currentTeam._id} messageType="team" />
+    </div>
+  );
+};
+
+export default TeamChatContainer;

--- a/Frontend/src/pages/HomePage.jsx
+++ b/Frontend/src/pages/HomePage.jsx
@@ -1,20 +1,54 @@
+// Frontend/src/pages/HomePage.jsx
 import { useChatStore } from "../store/useChatStore";
+import { useAuthStore } from "../store/useAuthStore"; // Import useAuthStore
 
 import Sidebar from "../components/Sidebar";
-import NoChatSelected from "../components/NoChatSelected";
-import ChatContainer from "../components/ChatContainer";
+import NoChatSelected from "../components/NoChatSelected"; // Used if no team and no selected user
+import ChatContainer from "../components/ChatContainer"; // For direct messages
+import TeamChatContainer from "../components/TeamChatContainer"; // For team messages
+import { useEffect } from "react";
 
 const HomePage = () => {
-  const { selectedUser } = useChatStore();
+  const { selectedUser, clearSelectedUser } = useChatStore();
+  const { currentTeam } = useAuthStore(); // Get currentTeam
+
+  // Effect to clear selected user if current team changes or becomes null
+  // This prevents showing a DM from a previous team context.
+  useEffect(() => {
+    if (!currentTeam) {
+      clearSelectedUser();
+    }
+    // Also, if selectedUser exists but is not in currentTeam (e.g. after leaving/joining new team), clear it.
+    // This logic could be more robust in setSelectedUser in store, but this is a safeguard.
+    if (selectedUser && currentTeam && selectedUser.team !== currentTeam._id) {
+        clearSelectedUser();
+    }
+
+  }, [currentTeam, selectedUser, clearSelectedUser]);
+
+
+  let mainContent;
+
+  if (currentTeam) {
+    if (selectedUser) {
+      mainContent = <ChatContainer />;
+    } else {
+      // If in a team but no specific user is selected for DM, show team chat
+      mainContent = <TeamChatContainer />;
+    }
+  } else {
+    // Not in a team, Sidebar will show prompt to join/create.
+    // NoChatSelected can show a generic message here.
+    mainContent = <NoChatSelected message="Join or create a team to start chatting with your colleagues!" />;
+  }
 
   return (
     <div className="h-screen bg-base-200">
-      <div className="flex items-center justify-center pt-20 px-4">
-        <div className="bg-base-100 rounded-lg shadow-cl w-full max-w-6xl h-[calc(100vh-8rem)]">
+      <div className="flex items-center justify-center pt-20 px-4"> {/* Ensure navbar height is accounted for */}
+        <div className="bg-base-100 rounded-lg shadow-xl w-full max-w-6xl h-[calc(100vh-6rem)]"> {/* Adjusted shadow and height */}
           <div className="flex h-full rounded-lg overflow-hidden">
             <Sidebar />
-
-            {!selectedUser ? <NoChatSelected /> : <ChatContainer />}
+            {mainContent}
           </div>
         </div>
       </div>

--- a/Frontend/src/pages/TeamsPage.jsx
+++ b/Frontend/src/pages/TeamsPage.jsx
@@ -1,0 +1,142 @@
+// Frontend/src/pages/TeamsPage.jsx
+import { useState } from "react";
+import { axiosInstance } from "../lib/axios";
+import { useAuthStore } from "../store/useAuthStore";
+import toast from "react-hot-toast";
+import { useNavigate } from "react-router-dom";
+
+const TeamsPage = () => {
+  const [teamName, setTeamName] = useState("");
+  const [joinCode, setJoinCode] = useState("");
+  const [createdTeamCode, setCreatedTeamCode] = useState(null);
+  const [isLoadingCreate, setIsLoadingCreate] = useState(false);
+  const [isLoadingJoin, setIsLoadingJoin] = useState(false);
+
+  const { setCurrentTeam, authUser } = useAuthStore();
+  const navigate = useNavigate();
+
+  const handleCreateTeam = async (e) => {
+    e.preventDefault();
+    if (!teamName.trim()) {
+      toast.error("Team name is required.");
+      return;
+    }
+    setIsLoadingCreate(true);
+    setCreatedTeamCode(null);
+    try {
+      const res = await axiosInstance.post("/teams", { name: teamName });
+      toast.success(`Team "${res.data.name}" created successfully!`);
+      setCreatedTeamCode(res.data.code);
+      setCurrentTeam(res.data); // Update auth store with the new team
+      setTeamName("");
+      // Optionally redirect or update UI further
+      // navigate("/"); // Example redirect
+    } catch (error) {
+      toast.error(error.response?.data?.message || "Failed to create team.");
+      console.error("Create team error:", error);
+    } finally {
+      setIsLoadingCreate(false);
+    }
+  };
+
+  const handleJoinTeam = async (e) => {
+    e.preventDefault();
+    if (!joinCode.trim()) {
+      toast.error("Team code is required.");
+      return;
+    }
+    setIsLoadingJoin(true);
+    try {
+      const res = await axiosInstance.post("/teams/join", { code: joinCode });
+      toast.success(`Successfully joined team "${res.data.name}"!`);
+      setCurrentTeam(res.data); // Update auth store with the joined team
+      setJoinCode("");
+      navigate("/"); // Redirect to home page after joining a team
+    } catch (error) {
+      toast.error(error.response?.data?.message || "Failed to join team.");
+      console.error("Join team error:", error);
+    } finally {
+      setIsLoadingJoin(false);
+    }
+  };
+
+  // If user is already in a team, perhaps show different UI or a message
+  if (authUser?.team) {
+    return (
+      <div className="flex flex-col items-center justify-center min-h-screen bg-base-200 pt-16">
+        <div className="card w-full max-w-md bg-base-100 shadow-xl p-6">
+          <h1 className="text-2xl font-bold text-center mb-4">Your Team</h1>
+          <p className="text-center mb-2">You are currently a member of team: <strong>{authUser.team.name}</strong>.</p>
+          <p className="text-center text-sm mb-1">Team Code: <span className="font-mono bg-base-300 px-2 py-1 rounded">{authUser.team.code}</span></p>
+          <p className="text-center text-sm">Owner: {authUser.team.owner === authUser._id ? "You" : "Another user"}</p>
+          <button onClick={() => navigate("/")} className="btn btn-primary w-full mt-4">
+            Go to Chat
+          </button>
+           {/* TODO: Add a "Leave Team" button later if needed */}
+        </div>
+      </div>
+    );
+  }
+
+
+  return (
+    <div className="flex flex-col items-center justify-center min-h-screen bg-base-200 pt-16">
+      <div className="card w-full max-w-md bg-base-100 shadow-xl">
+        <div className="card-body">
+          <h2 className="card-title text-2xl justify-center">Create a Team</h2>
+          <form onSubmit={handleCreateTeam} className="space-y-4">
+            <div>
+              <label htmlFor="teamName" className="label">
+                <span className="label-text">Team Name</span>
+              </label>
+              <input
+                type="text"
+                id="teamName"
+                placeholder="Enter team name"
+                className="input input-bordered w-full"
+                value={teamName}
+                onChange={(e) => setTeamName(e.target.value)}
+                disabled={isLoadingCreate}
+              />
+            </div>
+            <button type="submit" className="btn btn-primary w-full" disabled={isLoadingCreate}>
+              {isLoadingCreate ? <span className="loading loading-spinner"></span> : "Create Team"}
+            </button>
+          </form>
+          {createdTeamCode && (
+            <div className="mt-4 p-3 bg-base-200 rounded-lg">
+              <p className="text-sm">Team created! Your join code is:
+                <strong className="ml-1 font-mono bg-base-300 px-2 py-1 rounded">{createdTeamCode}</strong>
+              </p>
+            </div>
+          )}
+
+          <div className="divider my-6">OR</div>
+
+          <h2 className="card-title text-2xl justify-center">Join a Team</h2>
+          <form onSubmit={handleJoinTeam} className="space-y-4">
+            <div>
+              <label htmlFor="joinCode" className="label">
+                <span className="label-text">Team Code</span>
+              </label>
+              <input
+                type="text"
+                id="joinCode"
+                placeholder="Enter team code"
+                className="input input-bordered w-full"
+                value={joinCode}
+                onChange={(e) => setJoinCode(e.target.value)}
+                disabled={isLoadingJoin}
+              />
+            </div>
+            <button type="submit" className="btn btn-secondary w-full" disabled={isLoadingJoin}>
+              {isLoadingJoin ? <span className="loading loading-spinner"></span> : "Join Team"}
+            </button>
+          </form>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default TeamsPage;

--- a/Frontend/src/store/useAuthStore.js
+++ b/Frontend/src/store/useAuthStore.js
@@ -1,3 +1,4 @@
+// Frontend/src/store/useAuthStore.js
 import { create } from "zustand";
 import { axiosInstance } from "../lib/axios.js";
 import toast from "react-hot-toast";
@@ -7,6 +8,7 @@ const BASE_URL = import.meta.env.MODE === "development" ? "http://localhost:5001
 
 export const useAuthStore = create((set, get) => ({
   authUser: null,
+  currentTeam: null,
   isSigningUp: false,
   isLoggingIn: false,
   isUpdatingProfile: false,
@@ -15,29 +17,30 @@ export const useAuthStore = create((set, get) => ({
   socket: null,
 
   checkAuth: async () => {
+    set({ isCheckingAuth: true });
     try {
       const res = await axiosInstance.get("/auth/check");
-
-      set({ authUser: res.data });
-      get().connectSocket();
+      set({ authUser: res.data, currentTeam: res.data.team || null });
+      if (res.data) { // Connect socket only if authUser is successfully fetched
+        get().connectSocket();
+      }
     } catch (error) {
       console.log("Error in checkAuth:", error);
-      set({ authUser: null });
+      set({ authUser: null, currentTeam: null });
     } finally {
       set({ isCheckingAuth: false });
     }
   },
 
-   
   signup: async (data) => {
     set({ isSigningUp: true });
     try {
       const res = await axiosInstance.post("/auth/signup", data);
-      set({ authUser: res.data });
+      set({ authUser: res.data, currentTeam: res.data.team || null });
       toast.success("Account created successfully");
-      get().connectSocket();
+      get().connectSocket(); // Connect socket after signup
     } catch (error) {
-      toast.error(error.response.data.message);
+      toast.error(error.response?.data?.message || "Signup failed");
     } finally {
       set({ isSigningUp: false });
     }
@@ -47,12 +50,11 @@ export const useAuthStore = create((set, get) => ({
     set({ isLoggingIn: true });
     try {
       const res = await axiosInstance.post("/auth/login", data);
-      set({ authUser: res.data });
+      set({ authUser: res.data, currentTeam: res.data.team || null });
       toast.success("Logged in successfully");
-
-      get().connectSocket();
+      get().connectSocket(); // Connect socket after login
     } catch (error) {
-      toast.error(error.response.data.message);
+      toast.error(error.response?.data?.message || "Login failed");
     } finally {
       set({ isLoggingIn: false });
     }
@@ -60,12 +62,17 @@ export const useAuthStore = create((set, get) => ({
 
   logout: async () => {
     try {
+      // Emit leaveTeamRoom before actual logout and socket disconnect
+      const { socket, currentTeam } = get();
+      if (socket?.connected && currentTeam?._id) {
+        socket.emit("leaveTeamRoom", currentTeam._id);
+      }
       await axiosInstance.post("/auth/logout");
-      set({ authUser: null });
+      set({ authUser: null, currentTeam: null });
       toast.success("Logged out successfully");
-      get().disconnectSocket();
+      get().disconnectSocket(); // Disconnect socket after logout
     } catch (error) {
-      toast.error(error.response.data.message);
+      toast.error(error.response?.data?.message || "Logout failed");
     }
   },
 
@@ -77,30 +84,74 @@ export const useAuthStore = create((set, get) => ({
       toast.success("Profile updated successfully");
     } catch (error) {
       console.log("error in update profile:", error);
-      toast.error(error.response.data.message);
+      toast.error(error.response?.data?.message || "Profile update failed");
     } finally {
       set({ isUpdatingProfile: false });
     }
   },
 
+  setCurrentTeam: (team) => {
+    const { socket, currentTeam: oldTeam } = get();
+    // If changing teams, leave old room and join new one
+    if (socket?.connected) {
+      if (oldTeam?._id && oldTeam._id !== team?._id) {
+        socket.emit("leaveTeamRoom", oldTeam._id);
+      }
+      if (team?._id) {
+        socket.emit("joinTeamRoom", team._id);
+      }
+    }
+    set({ currentTeam: team });
+    const authUser = get().authUser;
+    if (authUser) {
+        // Update authUser.team to be the full team object or null
+        set({ authUser: {...authUser, team: team }});
+    }
+  },
+
   connectSocket: () => {
-    const { authUser } = get();
+    const { authUser } = get(); // Get authUser, currentTeam will be fetched inside connect handler
     if (!authUser || get().socket?.connected) return;
 
-    const socket = io(BASE_URL, {
+    // Pass userId in query for backend to identify user
+    const newSocket = io(BASE_URL, {
       query: {
         userId: authUser._id,
       },
     });
-    socket.connect();
 
-    set({ socket: socket });
+    newSocket.on("connect", () => {
+      console.log("Socket connected:", newSocket.id);
+      set({ socket: newSocket }); // Set socket in store once connected
 
-    socket.on("getOnlineUsers", (userIds) => {
-      set({ onlineUsers: userIds });
+      // If user is part of a team, emit event to join team room
+      const currentTeamFromStore = get().currentTeam; // Re-fetch currentTeam from store
+      if (currentTeamFromStore?._id) {
+        newSocket.emit("joinTeamRoom", currentTeamFromStore._id);
+        console.log(`Emitted joinTeamRoom for team ${currentTeamFromStore._id}`);
+      }
+
+      newSocket.on("getOnlineUsers", (userIds) => {
+        set({ onlineUsers: userIds });
+      });
+    });
+
+    newSocket.on("disconnect", (reason) => {
+      console.log("Socket disconnected:", reason);
+      // No need to set socket to null here, as disconnectSocket handles cleanup
+    });
+
+    newSocket.on("connect_error", (err) => {
+      console.error("Socket connection error:", err.message);
+      // Potentially set socket to null or attempt reconnect with backoff later
     });
   },
+
   disconnectSocket: () => {
-    if (get().socket?.connected) get().socket.disconnect();
+    const socket = get().socket;
+    if (socket?.connected) {
+        socket.disconnect();
+    }
+    set({ socket: null, onlineUsers: [] });
   },
 }));

--- a/Frontend/src/store/useChatStore.js
+++ b/Frontend/src/store/useChatStore.js
@@ -1,14 +1,18 @@
+// Frontend/src/store/useChatStore.js
 import { create } from "zustand";
 import toast from "react-hot-toast";
 import { axiosInstance } from "../lib/axios";
-import { useAuthStore } from "./useAuthStore";
+import { useAuthStore } from "./useAuthStore"; // Import useAuthStore
 
 export const useChatStore = create((set, get) => ({
+  // ... (state variables as before) ...
   messages: [],
+  teamMessages: [],
   users: [],
   selectedUser: null,
   isUsersLoading: false,
   isMessagesLoading: false,
+  isTeamMessagesLoading: false,
 
   getUsers: async () => {
     set({ isUsersLoading: true });
@@ -16,53 +20,83 @@ export const useChatStore = create((set, get) => ({
       const res = await axiosInstance.get("/messages/users");
       set({ users: res.data });
     } catch (error) {
-      toast.error(error.response.data.message);
+      toast.error(error.response?.data?.message || "Failed to get users");
     } finally {
       set({ isUsersLoading: false });
     }
   },
 
   getMessages: async (userId) => {
-    set({ isMessagesLoading: true });
+    set({ isMessagesLoading: true, messages: [] });
     try {
-      const res = await axiosInstance.get(`/messages/${userId}`);
+      const res = await axiosInstance.get(`/messages/direct/${userId}`);
       set({ messages: res.data });
     } catch (error) {
-      toast.error(error.response.data.message);
+      toast.error(error.response?.data?.message || "Failed to get direct messages");
     } finally {
       set({ isMessagesLoading: false });
     }
   },
-  sendMessage: async (messageData) => {
-    const { selectedUser, messages } = get();
+
+  getTeamMessages: async (teamId) => {
+    set({ isTeamMessagesLoading: true, teamMessages: [] });
     try {
-      const res = await axiosInstance.post(`/messages/send/${selectedUser._id}`, messageData);
-      set({ messages: [...messages, res.data] });
+      const res = await axiosInstance.get(`/messages/team/${teamId}`);
+      set({ teamMessages: res.data });
     } catch (error) {
-      toast.error(error.response.data.message);
+      toast.error(error.response?.data?.message || "Failed to get team messages");
+    } finally {
+      set({ isTeamMessagesLoading: false });
     }
   },
 
-  subscribeToMessages: () => {
-    const { selectedUser } = get();
-    if (!selectedUser) return;
-
-    const socket = useAuthStore.getState().socket;
-
-    socket.on("newMessage", (newMessage) => {
-      const isMessageSentFromSelectedUser = newMessage.senderId === selectedUser._id;
-      if (!isMessageSentFromSelectedUser) return;
-
-      set({
-        messages: [...get().messages, newMessage],
-      });
-    });
+  sendMessage: async ({ chatId, messageType, text, image }) => {
+    if (!chatId || !messageType) {
+        const errMessage = "Chat ID or Message Type is missing.";
+        toast.error(errMessage);
+        throw new Error(errMessage);
+    }
+    try {
+      const payload = { messageType, text, image };
+      const res = await axiosInstance.post(`/messages/send/${chatId}`, payload);
+      return res.data;
+    } catch (error) {
+      toast.error(error.response?.data?.message || "Failed to send message");
+      throw error;
+    }
   },
 
-  unsubscribeFromMessages: () => {
-    const socket = useAuthStore.getState().socket;
-    socket.off("newMessage");
+  addMessageToStore: (newMessage) => {
+    const authUser = useAuthStore.getState().authUser; // Get authUser here
+    const currentTeamFromAuthStore = useAuthStore.getState().currentTeam;
+
+
+    if (newMessage.type === 'direct') {
+      const { selectedUser } = get();
+      if (selectedUser && authUser && currentTeamFromAuthStore &&
+          newMessage.teamId === currentTeamFromAuthStore._id && // Message must be in current team context
+          ((newMessage.senderId?._id === selectedUser._id && newMessage.receiverId?._id === authUser._id) ||
+           (newMessage.senderId?._id === authUser._id && newMessage.receiverId?._id === selectedUser._id))
+         ) {
+         set((state) => ({ messages: [...state.messages, newMessage] }));
+      }
+    } else if (newMessage.type === 'team') {
+       // TeamChatContainer's socket listener already checks if (newMessage.teamId === currentTeam._id)
+       // So, if addMessageToStore is called for a 'team' message, it's assumed to be for the current team.
+       set((state) => ({ teamMessages: [...state.teamMessages, newMessage] }));
+    }
   },
 
-  setSelectedUser: (selectedUser) => set({ selectedUser }),
+  setSelectedUser: (selectedUser) => {
+    // When a new user is selected for DM, also ensure currentTeam context is accurate
+    // This is more of a sanity check; selectedUser should always be from currentTeam.
+    const currentTeamId = useAuthStore.getState().currentTeam?._id;
+    if (selectedUser && selectedUser.team && selectedUser.team !== currentTeamId) {
+        toast.error("Error: Selected user is not in your current team.");
+        set({ selectedUser: null, messages: [] }); // Clear selection
+        return;
+    }
+    set({ selectedUser, messages: [] });
+  },
+  clearSelectedUser: () => set({ selectedUser: null, messages: []}),
 }));


### PR DESCRIPTION
This commit introduces the frontend implementation for the Teams feature, enabling you to create, join, and interact within team-specific chat environments. This complements the previously submitted backend for this feature.

Key frontend changes include:

1.  **State Management (`useAuthStore.js`, `useChatStore.js`)**:
    *   `useAuthStore`: Added `currentTeam` state, populated during login/signup/auth checks. Includes `setCurrentTeam` action for explicit updates. Handles socket room joining (`joinTeamRoom` event) and leaving (`leaveTeamRoom` event) based on team status.
    *   `useChatStore`:
        *   Added `teamMessages` state and `isTeamMessagesLoading` for team-specific messages.
        *   `getTeamMessages(teamId)`: Fetches messages for a team.
        *   `getMessages(userId)`: Updated to fetch direct messages via `/api/messages/direct/:userId`.
        *   Generic `sendMessage({ chatId, messageType, ... })`: Sends messages for both direct and team chats. Relies on socket events for local message updates to prevent duplication.
        *   `addMessageToStore(newMessage)`: Generic function to add incoming socket messages to `messages` or `teamMessages` based on context.

2.  **New Components & Pages**:
    *   `TeamsPage.jsx` (`/teams` route):
        *   Allows you to create a new team (displays join code) or join an existing team using a code.
        *   Updates `currentTeam` in `useAuthStore` upon success.
        *   Displays current team info if you are already a member.
    *   `TeamChatContainer.jsx`:
        *   Displays team group messages fetched via `getTeamMessages`.
        *   Handles real-time team messages via socket events.
        *   Uses the generic `MessageInput.jsx` for sending team messages.

3.  **Modified Components**:
    *   `Sidebar.jsx`:
        *   If you are not in a team, prompts you to join/create one with a link to `/teams`.
        *   If you are in a team, lists only members of that team (fetched via updated `/api/messages/users`).
    *   `ChatContainer.jsx` (for direct messages):
        *   Handles real-time direct messages via socket events, scoped to the current team and selected user.
        *   Uses the generic `MessageInput.jsx`.
    *   `MessageInput.jsx`:
        *   Refactored to accept `chatId` and `messageType` props to send messages to either a user or a team.
    *   `HomePage.jsx`:
        *   If you are in a team and no direct message recipient is selected, defaults to displaying `TeamChatContainer`.
        *   If a team member is selected from sidebar, displays `ChatContainer` for direct messages.
        *   If you are not in a team, displays `NoChatSelected` with a prompt.
    *   `Navbar.jsx`: Added a "Teams" link for authenticated users.
    *   `NoChatSelected.jsx`: Made more generic by accepting a message prop.

4.  **Socket Integration**:
    *   Client-side logic in `useAuthStore` emits `joinTeamRoom` and `leaveTeamRoom` events to the backend based on team status and changes.
    *   `TeamChatContainer` and `ChatContainer` listen for `newMessage` socket events and update their respective message lists.

This implementation provides a comprehensive UI for the new team functionalities, including team management, team-scoped group chat, and team-member-only direct messaging.